### PR TITLE
Support iPad's Swift Playgrounds

### DIFF
--- a/WriteYourLanguage.playground/Pages/Conclusion.xcplaygroundpage/Sources/Mu.swift
+++ b/WriteYourLanguage.playground/Pages/Conclusion.xcplaygroundpage/Sources/Mu.swift
@@ -8,7 +8,7 @@ public enum Token {
 
 public struct Lexer {
     public static func tokenize(_ input: String) -> [Token] {
-        return input.characters.flatMap {
+        return input.compactMap {
             switch $0 {
             case "(": return Token.parensOpen
             case ")": return Token.parensClose

--- a/WriteYourLanguage.playground/Pages/Interpreter.xcplaygroundpage/Sources/Lexer.swift
+++ b/WriteYourLanguage.playground/Pages/Interpreter.xcplaygroundpage/Sources/Lexer.swift
@@ -8,7 +8,7 @@ public enum Token {
 
 public struct Lexer {
     public static func tokenize(_ input: String) -> [Token] {
-        return input.characters.flatMap {
+        return input.compactMap {
             switch $0 {
             case "(": return Token.parensOpen
             case ")": return Token.parensClose

--- a/WriteYourLanguage.playground/Pages/Lexer.xcplaygroundpage/Contents.swift
+++ b/WriteYourLanguage.playground/Pages/Lexer.xcplaygroundpage/Contents.swift
@@ -24,7 +24,7 @@ enum Token {
 struct Lexer {
     
     static func tokenize(_ input: String) -> [Token] {
-        return input.characters.flatMap {
+        return input.compactMap {
             switch $0 {
                 case "(": return Token.parensOpen
                 case ")": return Token.parensClose

--- a/WriteYourLanguage.playground/Pages/Parser.xcplaygroundpage/Sources/Lexer.swift
+++ b/WriteYourLanguage.playground/Pages/Parser.xcplaygroundpage/Sources/Lexer.swift
@@ -8,7 +8,7 @@ public enum Token {
 
 public struct Lexer {
     public static func tokenize(_ input: String) -> [Token] {
-        return input.characters.flatMap {
+        return input.compactMap {
             switch $0 {
             case "(": return Token.parensOpen
             case ")": return Token.parensClose

--- a/WriteYourLanguage.playground/contents.xcplayground
+++ b/WriteYourLanguage.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' display-mode='rendered'>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
     <pages>
         <page name='Intro'/>
         <page name='Lexer'/>


### PR DESCRIPTION
# DESCRIPTION
I fixed xcplayground file to run on iPad's Swift playgrounds.
(just replaced "macos" with "ios". [see this article](https://stackoverflow.com/questions/44141548/swift-playgrounds-and-playground-books/47541481#47541481))

![IMG_0092](https://user-images.githubusercontent.com/19330/73933227-55c4dc00-491f-11ea-977b-2c01efc24bda.PNG)

and fixed some methods with modern one. commit: d62125f